### PR TITLE
fixed param name typos

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,5 +1,5 @@
 ﻿The MIT License (MIT)
-Copyright (c) <year> <copyright holders>
+Copyright (c) 2016 Shawn Doucet
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,34 @@
 # test-data
-a c# library for random data generation
+
+[![Version](https://img.shields.io/nuget/v/Voodoo.TestData.svg)](https://www.nuget.org/packages/Voodoo.TestData/)
+
+Test-data is a C# library for random data generation.
+
+
+##Getting Started
 
 You can reproduce the same set of test data by setting the seed.
 
+```
 TestHelper.SetRandomDataSeed(1);
+```
 
 there are a series of static methods to generate data of various types
 
+```
 TestHelper.Data.Int(1, 10);
+```
 
 You can randomize all of the primitives on an object using the randomizer
 
+```
 var subject = new Product();
 TestHelper.Randomizer.Randomize(subject);
+```
 
 You can create new population strategies or replace the existing ones
 
+```
 var product1 = new Product() { ProductName = "Test1" };
 var product2 = new Product() { ProductName = "Test2" };
 var strategy = new PredefinedSetTypeStrategy<Product>(new Product[] { product1, product2 });
@@ -23,3 +36,8 @@ TestHelper.Randomizer.AddOrReplaceTypeStrategy<Product>(strategy);
 
 var test = new OrderDetail();
 TestHelper.Randomizer.Ranomize(test);
+```
+
+##License
+
+[MIT](LICENSE.txt)

--- a/Voodoo.TestData/RandomDataGenerator.cs
+++ b/Voodoo.TestData/RandomDataGenerator.cs
@@ -57,12 +57,12 @@ namespace Voodoo.TestData
 			return num;
 		}
 
-		public string GibberishText(int lenght)
+		public string GibberishText(int length)
 		{
 			const int startNum = 97;
 			const int endNum = 122;
 			var sb = new StringBuilder();
-			for (var i = 0; i <= lenght - 1; i++)
+			for (var i = 0; i <= length - 1; i++)
 			{
 				var num = Int(startNum, endNum);
 				var c = ((char) num);
@@ -78,12 +78,12 @@ namespace Voodoo.TestData
 			return num == 1;
 		}
 
-		public string TextWithFunkySymbols(int lenght)
+		public string TextWithFunkySymbols(int length)
 		{
 			var startNum = 32;
 			var endNum = 126;
 			var sb = new StringBuilder();
-			for (var i = 0; i <= lenght - 1; i++)
+			for (var i = 0; i <= length - 1; i++)
 			{
 				var temp = ((char) Int(startNum, endNum)).ToString();
 				while ((temp.Equals(">")) || (temp.Equals("<")))
@@ -95,12 +95,12 @@ namespace Voodoo.TestData
 			return sb.ToString();
 		}
 
-		public string Characters(int lenght)
+		public string Characters(int length)
 		{
 			const int startNum = 32;
 			const int endNum = 47;
 			var sb = new StringBuilder();
-			for (var i = 0; i <= lenght - 1; i++)
+			for (var i = 0; i <= length - 1; i++)
 			{
 				var temp = ((char) Int(startNum, endNum)).ToString();
 				while ((temp.Equals(">")) || (temp.Equals("<")))


### PR DESCRIPTION
Several methods had parameters named `lenght`  instead of `length`
